### PR TITLE
nginx.prod.confに記載していたALBのDNS名の最適化

### DIFF
--- a/.github/workflows/store-front_deploy.yaml
+++ b/.github/workflows/store-front_deploy.yaml
@@ -52,12 +52,13 @@ jobs:
         id: build-nginx
         env:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          NEXTJS_ALB_HOST: ${{ secrets.NEXTJS_ALB_HOST }}
         run: |
           set -x
           echo "ECR_REGISTRY=$ECR_REGISTRY"
           echo "NGINX_ECR_REPO=$NGINX_ECR_REPO"
 
-          docker build -f nginx/Dockerfile -t $ECR_REGISTRY/$NGINX_ECR_REPO:$IMAGE_TAG ./nginx
+          docker build --build-arg NEXTJS_ALB_HOST=${NEXTJS_ALB_HOST} -f nginx/Dockerfile -t $ECR_REGISTRY/$NGINX_ECR_REPO:$IMAGE_TAG ./nginx
           docker tag $ECR_REGISTRY/$NGINX_ECR_REPO:$IMAGE_TAG $ECR_REGISTRY/$NGINX_ECR_REPO:$IMAGE_TAG
           docker push $ECR_REGISTRY/$NGINX_ECR_REPO:$IMAGE_TAG
           docker tag $ECR_REGISTRY/$NGINX_ECR_REPO:$IMAGE_TAG $ECR_REGISTRY/$NGINX_ECR_REPO:latest

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -1,11 +1,17 @@
 # Nginx 1.24（軽量な Alpine ベース）を使用
 FROM nginx:1.24-alpine
 
+# gettextを入れて envsubst を使えるようにする
+RUN apk add --no-cache gettext 
+
 # 環境切り替え（dev または prod）で設定ファイルを分岐
 ARG NGINX_ENV=prod
+ARG NEXTJS_ALB_HOST
 
 # 環境に応じた nginx.conf をコピー
-COPY nginx.${NGINX_ENV}.conf /etc/nginx/nginx.conf
+COPY nginx.${NGINX_ENV}.conf /etc/nginx/nginx.templete.conf
 
+# 環境変数を埋め込んで、最終的な nginx.conf を生成
+RUN envsubst '${NEXTJS_ALB_HOST}' < /etc/nginx/nginx.templete.conf > /etc/nginx/nginx.conf
 # 必要に応じて静的ファイルやその他設定をここで追加可能
 # COPY ./static /usr/share/nginx/html

--- a/nginx/nginx.prod.conf
+++ b/nginx/nginx.prod.conf
@@ -8,7 +8,7 @@ http {
     sendfile        on;
 
     upstream nextjs_ssr {
-        server http://internal-alb-nextjs-75600075.ap-northeast-1.elb.amazonaws.com:80;
+        server internal-alb-nextjs-75600075.ap-northeast-1.elb.amazonaws.com:80;
     }
 
     server {

--- a/nginx/nginx.prod.conf
+++ b/nginx/nginx.prod.conf
@@ -8,7 +8,7 @@ http {
     sendfile        on;
 
     upstream nextjs_ssr {
-        server internal-alb-nextjs-75600075.ap-northeast-1.elb.amazonaws.com:80;
+        server ${NEXTJS_ALB_HOST}:80;
     }
 
     server {


### PR DESCRIPTION
## ■概要：
本番環境用の`nginx.prod.conf`において、ALBのホスト名をハードコーディングするのではなく、環境変数としてGitHub>Secretsに登録し、ビルド時に`--build-arg`で動的に渡せるように変更。

本対応では、`${NEXTJS_ALB_HOST}`をテンプレート変数として利用し、Dockerファイル内で`envsubst`により動的に埋め込む方式に変更した。これにより、環境ごとに柔軟なビルドが可能となる。

## ■稼働確認について：
変更後、下記について問題ないことを確認済。

- GitHub Actionsが問題なく完了すること。
[デプロイログはこちら](https://github.com/dentsusoken/aipit-frontend-nextjs/actions/runs/15432063031)
- ALB ⇒ Nginx ⇒ ALB ⇒ Next.jsに接続できること。
- GitHub ActionsによるECRのイメージ更新ができていること。
- GitHub ActionsによるECSのタスク定義更新およびデプロイができていること。

